### PR TITLE
DAVE-36

### DIFF
--- a/src/components/CanvasMetadata/CanvasMetadata.jsx
+++ b/src/components/CanvasMetadata/CanvasMetadata.jsx
@@ -9,8 +9,12 @@ class CanvasMetadata extends Component {
 
   render () {
     let params = this.props.params
+    // return null for gridbiew otherwise show metadata for current canvasId(s)
     if (params.view !== 'g') {
       let isOdd = canvasIdIsOdd(params.canvasId)
+      // If we're in TwoUpView we need to display 2 sets of metadata, unless
+      // we are looking at the first canvasId OR the last canvasId when there
+      // is an even number of canvases
       if (
         (params.view === '2') &&
         (params.canvasId !== '0') &&
@@ -20,13 +24,16 @@ class CanvasMetadata extends Component {
         let data1, data2
         let metadata1, metadata2
 
+        // If we're looking at an even canvasId display it and the one before
         if (!isOdd) {
           data1 = data.sequences[params.sequence].canvases[parseInt(params.canvasId) - 1]
           data2 = data.sequences[params.sequence].canvases[params.canvasId]
+        // If we're looking at an odd canvasId display it and the one after
         } else {
           data1 = data.sequences[params.sequence].canvases[params.canvasId]
           data2 = data.sequences[params.sequence].canvases[parseInt(params.canvasId) + 1]
         }
+        // Build two metadata displays
         metadata1 = concatMetadata(data1.metadata, additionalMetadata(data1))
         metadata2 = concatMetadata(data2.metadata, additionalMetadata(data2))
         return (
@@ -37,6 +44,9 @@ class CanvasMetadata extends Component {
             <KeyPairMetadata metadata={metadata2} />
           </div>
         )
+      // If we're looking at the OneUpView, or one of the special cases for
+      // TwoUpView mentioned above, we display only the current canvasId
+      // metadata.
       } else {
         let data = this.props.data.sequences[params.sequence].canvases[params.canvasId]
         let metadata = concatMetadata(data.metadata, additionalMetadata(data))

--- a/src/components/CanvasMetadata/CanvasMetadata.jsx
+++ b/src/components/CanvasMetadata/CanvasMetadata.jsx
@@ -3,19 +3,51 @@ import React, { Component, PropTypes } from 'react'
 import KeyPairMetadata from '../KeyPairMetadata/'
 import concatMetadata from '../../modules/concatMetadata.js'
 import additionalMetadata from '../../modules/additionalMetadata.js'
+import canvasIdIsOdd from '../../modules/canvasIdIsOdd.js'
 
 class CanvasMetadata extends Component {
 
   render () {
-    if (this.props.params.view !== 'g') {
-      let data = this.props.data.sequences[this.props.params.sequence].canvases[this.props.params.canvasId]
-      let metadata = concatMetadata(data.metadata, additionalMetadata(data))
-      return (
-        <div>
-          <h2>Metadata</h2>
-          <KeyPairMetadata metadata={metadata} />
-        </div>
-      )
+    let params = this.props.params
+    if (params.view !== 'g') {
+      let isOdd = canvasIdIsOdd(params.canvasId)
+      if (
+        (params.view === '2') &&
+        (params.canvasId !== '0') &&
+        !(parseInt(params.canvasId) === this.props.data.sequences[this.props.params.sequence].canvases.length - 1 && isOdd)
+      ) {
+        let data = this.props.data
+        let data1, data2
+        let metadata1, metadata2
+
+        if (!isOdd) {
+          data1 = data.sequences[params.sequence].canvases[parseInt(params.canvasId) - 1]
+          data2 = data.sequences[params.sequence].canvases[params.canvasId]
+        } else {
+          data1 = data.sequences[params.sequence].canvases[params.canvasId]
+          data2 = data.sequences[params.sequence].canvases[parseInt(params.canvasId) + 1]
+        }
+        metadata1 = concatMetadata(data1.metadata, additionalMetadata(data1))
+        metadata2 = concatMetadata(data2.metadata, additionalMetadata(data2))
+        return (
+          <div>
+            <h2>Metadata <em>(left)</em></h2>
+            <KeyPairMetadata metadata={metadata1} />
+            <h2>Metadata <em>(right)</em></h2>
+            <KeyPairMetadata metadata={metadata2} />
+          </div>
+        )
+      } else {
+        let data = this.props.data.sequences[params.sequence].canvases[params.canvasId]
+        let metadata = concatMetadata(data.metadata, additionalMetadata(data))
+
+        return (
+          <div>
+            <h2>Metadata</h2>
+            <KeyPairMetadata metadata={metadata} />
+          </div>
+        )
+      }
     } else {
       return null
     }

--- a/src/components/DigitalArtifact/DigitalArtifact.jsx
+++ b/src/components/DigitalArtifact/DigitalArtifact.jsx
@@ -20,19 +20,21 @@ class DigitalArtifact extends Component {
           data={this.props.data}
           params={this.props.params}
         >
-          <CurrentView
-            data={this.props.data}
-            params={this.props.params}
-          />
-          <Drawer
-            data={this.props.data}
-            params={this.props.params}
-          />
-          <div className={classes.bottomBar}>
-            <SecondaryToolbar
+          <div>
+            <CurrentView
               data={this.props.data}
               params={this.props.params}
             />
+            <Drawer
+              data={this.props.data}
+              params={this.props.params}
+            />
+            <div className={classes.bottomBar}>
+              <SecondaryToolbar
+                data={this.props.data}
+                params={this.props.params}
+              />
+            </div>
           </div>
         </SwipeArea>
       </div>

--- a/src/components/GridView/GridView.scss
+++ b/src/components/GridView/GridView.scss
@@ -1,4 +1,5 @@
 .gridview {
-  height: 100%;
+  height: calc(90vh - 112px);
+  overflow-y: scroll;
   padding-bottom: 66px;
 }

--- a/src/components/SwipeArea/SwipeArea.jsx
+++ b/src/components/SwipeArea/SwipeArea.jsx
@@ -68,7 +68,6 @@ class SwipeArea extends Component {
       <Swipeable
         onSwipedRight={this.swipeRight}
         onSwipedLeft={this.swipeLeft}
-        className={this.props.params.view !== 'g' ? 'swipeArea' : classes.gridStyle}
       >
         {this.props.children}
       </Swipeable>

--- a/src/components/TwoUpView/TwoUpView.jsx
+++ b/src/components/TwoUpView/TwoUpView.jsx
@@ -4,21 +4,17 @@ import ArtifactImage from '../ArtifactImage/'
 import buildArtifactImage from '../../modules/buildArtifactImage.js'
 import classes from './TwoUpView.scss'
 import OneUpView from '../OneUpView/'
-
+import canvasIdIsOdd from '../../modules/canvasIdIsOdd.js'
 class TwoUpView extends Component {
-
-  constructor (props) {
-    super(props)
-  }
 
   render () {
     // If we are on the first page or the last page of an even numbered
     // sequence return the single page view instead.
-    var canvasId = parseInt(this.props.params.canvasId)
-    var lastcanvasId = this.props.data.sequences[this.props.params.sequence].canvases.length - 1
-    var pageIsEven = (canvasId % 2 === 1)
-
-    if (canvasId === 0 || ((canvasId === lastcanvasId) && pageIsEven)) {
+    // We use canvasIdIsOdd because canvasId starts at 0
+    let canvasId = parseInt(this.props.params.canvasId)
+    let lastcanvasId = this.props.data.sequences[this.props.params.sequence].canvases.length - 1
+    let isOdd = canvasIdIsOdd(canvasId)
+    if (canvasId === 0 || ((canvasId === lastcanvasId) && isOdd)) {
       return (
         <OneUpView
           data={this.props.data}
@@ -30,11 +26,10 @@ class TwoUpView extends Component {
     var imageObject1
     var imageObject2
 
-    if (!pageIsEven) {
+    if (!isOdd) {
       imageObject1 = buildArtifactImage(this.props.data, this.props.params, -1)
       imageObject2 = buildArtifactImage(this.props.data, this.props.params)
-    }
-    else {
+    } else {
       imageObject1 = buildArtifactImage(this.props.data, this.props.params)
       imageObject2 = buildArtifactImage(this.props.data, this.props.params, 1)
     }
@@ -47,20 +42,20 @@ class TwoUpView extends Component {
             showTitle
           />
         </div>
-      <div className={classes.splitDisplay}>
+        <div className={classes.splitDisplay}>
           <ArtifactImage
             imageObject={imageObject2}
             showTitle
           />
         </div>
       </div>
-     )
+    )
   }
 }
 
 TwoUpView.propTypes = {
-  data: React.PropTypes.object.isRequired,
-  params: React.PropTypes.object.isRequired
+  data: PropTypes.object.isRequired,
+  params: PropTypes.object.isRequired
 }
 
 export default TwoUpView

--- a/src/modules/canvasIdIsOdd.js
+++ b/src/modules/canvasIdIsOdd.js
@@ -1,0 +1,5 @@
+function canvasIdIsOdd (canvasId) {
+  return (parseInt(canvasId) % 2 === 1)
+}
+
+export default canvasIdIsOdd

--- a/tests/components/CanvasMetadata/CanvasMetadata.spec.js
+++ b/tests/components/CanvasMetadata/CanvasMetadata.spec.js
@@ -25,11 +25,11 @@ describe('(View) CanvasMetadata', () => {
   })
 
   it('Renders a title', () => {
-    expect(_component.find('h2')).to.exist
+    expect(_component.find('h2')).to.have.length(1)
   })
 
   it('Renders a <KeyPairMetadata/> component', () => {
-    expect(_component.find(KeyPairMetadata)).to.exist
+    expect(_component.find(KeyPairMetadata)).to.have.length(1)
   })
 
   it('Returns null on grid view', () => {

--- a/tests/components/CanvasMetadata/CanvasMetadata.spec.js
+++ b/tests/components/CanvasMetadata/CanvasMetadata.spec.js
@@ -6,7 +6,7 @@ import { shallow } from 'enzyme'
 describe('(View) CanvasMetadata', () => {
   let _component
   let _data = {
-    sequences: [{ canvases: [{}]}],
+    sequences: [{ canvases: [{},{},{},{},{}]}],
     metadata: [{label: 'Label', value: 'Value'}, {}],
     label: 'Not technically in metadata'
   }
@@ -40,6 +40,60 @@ describe('(View) CanvasMetadata', () => {
     }
     _component = shallow(<CanvasMetadata data={_data} params={_params}/>)
     expect(_component.html()).to.equal(null)
+  })
+
+  it('Renders 1 <KeyPairMetadata/> component on two up page for canvasID = 0', () => {
+    _params = {
+      sequence: '0',
+      canvasId: '0',
+      view: '2'
+    }
+    _component = shallow(<CanvasMetadata data={_data} params={_params}/>)
+    expect(_component.find(KeyPairMetadata)).to.have.length(1)
+  })
+
+  it('Renders 2 <KeyPairMetadata/> components on two up page', () => {
+    _params = {
+      sequence: '0',
+      canvasId: '1',
+      view: '2'
+    }
+    _component = shallow(<CanvasMetadata data={_data} params={_params}/>)
+    expect(_component.find(KeyPairMetadata)).to.have.length(2)
+  })
+
+  it('Renders 2 <KeyPairMetadata/> components on two up page', () => {
+    _params = {
+      sequence: '0',
+      canvasId: '2',
+      view: '2'
+    }
+    _component = shallow(<CanvasMetadata data={_data} params={_params}/>)
+    expect(_component.find(KeyPairMetadata)).to.have.length(2)
+  })
+
+  it('Renders 2 <KeyPairMetadata/> components on two up page for last canvasID with odd length', () => {
+    _params = {
+      sequence: '0',
+      canvasId: '4',
+      view: '2'
+    }
+    _component = shallow(<CanvasMetadata data={_data} params={_params}/>)
+    expect(_component.find(KeyPairMetadata)).to.have.length(2)
+  })
+  it('Renders 1 <KeyPairMetadata/> component on two up page for last canvasID with even length', () => {
+    _data = {
+      sequences: [{ canvases: [{},{},{},{},{},{}]}],
+      metadata: [{label: 'Label', value: 'Value'}, {}],
+      label: 'Not technically in metadata'
+    }
+    _params = {
+      sequence: '0',
+      canvasId: '5',
+      view: '2'
+    }
+    _component = shallow(<CanvasMetadata data={_data} params={_params}/>)
+    expect(_component.find(KeyPairMetadata)).to.have.length(1)
   })
 
 })

--- a/tests/modules/canvasIdIsOdd.spec.js
+++ b/tests/modules/canvasIdIsOdd.spec.js
@@ -1,0 +1,15 @@
+import canvasIdIsOdd from 'modules/canvasIdIsOdd'
+
+describe('(Module) canvasIdIsOdd', () => {
+
+  let _result
+  it('Return true for odd', () => {
+    _result = canvasIdIsOdd('1')
+    expect(_result).to.equal(true)
+  })
+
+  it('Return false for even', () => {
+    _result = canvasIdIsOdd('2')
+    expect(_result).to.equal(false)
+  })
+})


### PR DESCRIPTION
Changes to the following address adding two sets of metadata for the TwoUpView:
 * CanvasMetadata.jsx
 * TwoUpView.jsx
 * canvasIdIsOdd.js
 * CanvasMetadata.spec.js
 * canvasIdIsOdd.spec.js

Changes to the following are fixes for DAVE-54:
 * DigitalArtifact.jsx
 * GridView.scss