### PR TITLE
Allow manifest files to come from more than a single defined location

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,7 +33,8 @@ Files will be compiled to `~/dist`.
 
 :manifestId/:sequence/:view/:canvasId/detail
 
- * :manifest = currently manifest `id`
+ * :base = `[ 0, 1, 2 ... ]` = base uri for the manifest file
+ * :manifest = currently manifest filename without `.json` extension
  * :sequence = `[ 0, 1, 2 ... ]` = current sequence
  * :view = `[ 1, 2, g ]` = 1-up, 2-up, or grid
  * :canvasId = `[ 0, 1, 2 ... ]` = current page of artifact
@@ -43,7 +44,7 @@ Source may be passed by appending ?ref=URI which will be retained while navigati
 
 Example:
 
-` http://dave.library.nd.edu/manifest-1/0/1/3/detail?ref=http://google.com
+` http://dave.library.nd.edu/0/manifest-1/0/1/3/detail?ref=http://google.com
 `
 
 ## Deploy Pre Production

--- a/README.md
+++ b/README.md
@@ -27,11 +27,11 @@ Files will be compiled to `~/dist`.
 
 ## React Routes
 
-:manifestId/:sequence/:view
+:base/:manifestId/:sequence/:view
 
-:manifestId/:sequence/:view/:canvasId
+:base/:manifestId/:sequence/:view/:canvasId
 
-:manifestId/:sequence/:view/:canvasId/detail
+:base/:manifestId/:sequence/:view/:canvasId/detail
 
  * :base = `[ 0, 1, 2 ... ]` = base uri for the manifest file
  * :manifest = currently manifest filename without `.json` extension

--- a/src/configuration/variables.js
+++ b/src/configuration/variables.js
@@ -10,7 +10,8 @@ export const colors = {
 import Logo from './assets/library.logo.png'
 export const logo = Logo
 
-export const manifestBaseUrl = 'http://dave.manifests.test.library.nd.edu.s3.amazonaws.com/sample_data/manifests/'
+export const manifestBaseUrls = [ 'http://dave.manifests.test.library.nd.edu.s3.amazonaws.com/sample_data/manifests/'
+]
 
 export const whitelist = [
   'library.nd.edu'

--- a/src/modules/targetPath.js
+++ b/src/modules/targetPath.js
@@ -10,7 +10,7 @@
  */
 
 function targetPath (params) {
-  var path = '/' + params.manifest
+  var path = '/' + params.base + '/' + params.manifest
 
   if (params.sequence) {
     path += '/' + params.sequence

--- a/src/routes/Home/components/HomeView.js
+++ b/src/routes/Home/components/HomeView.js
@@ -79,9 +79,9 @@ export const HomeView = () => (
         </ul>
         <p>Example links are here:</p>
         <ul>
-          <li><Link to='/manifest-1/1/2/0?ref=http://onesearch.library.nd.edu/primo_library/libweb/action/search.do;jsessionid=EA0BCCC11BE18F49EF29576941A3A97E?mode=Basic&vid=NDU&tab=onesearch&'>Example 1</Link></li>
-          <li><Link to='/manifest-3/1/1/16?ref=http://google.com'>Example 2</Link></li>
-          <li><Link to='/manifest-single/0/1/0'>Example 3</Link></li>
+          <li><Link to='/0/manifest-1/1/2/0?ref=http://onesearch.library.nd.edu/primo_library/libweb/action/search.do;jsessionid=EA0BCCC11BE18F49EF29576941A3A97E?mode=Basic&vid=NDU&tab=onesearch&'>Example 1</Link></li>
+          <li><Link to='/0/manifest-3/1/1/16?ref=http://google.com'>Example 2</Link></li>
+          <li><Link to='/0/manifest-single/0/1/0'>Example 3</Link></li>
           </ul>
       </div>
       <div className={classes.description}>

--- a/src/routes/Manifest/components/Manifest.js
+++ b/src/routes/Manifest/components/Manifest.js
@@ -6,7 +6,7 @@ import { CircularProgress } from 'material-ui'
 class Manifest extends Component {
 
   componentWillMount () {
-    this.props.fetchManifest(this.props.params.manifest)
+    this.props.fetchManifest(this.props.params.base, this.props.params.manifest)
   }
 
   render () {

--- a/src/routes/Manifest/index.js
+++ b/src/routes/Manifest/index.js
@@ -1,7 +1,7 @@
 import { injectReducer } from '../../store/reducers'
 export default (store) => ({
 
-  path: ':manifest(/:sequence)(/:view)(/:canvasId)(/:detail)',
+  path: ':base/:manifest(/:sequence)(/:view)(/:canvasId)(/:detail)',
   getComponent (nextState, next) {
     require.ensure([
       './containers/ManifestContainer',

--- a/src/routes/Manifest/modules/manifest.js
+++ b/src/routes/Manifest/modules/manifest.js
@@ -1,7 +1,7 @@
 import type { ManifestObject, ManifestStateObject } from '../interfaces/manifest.js'
 import jsonClean from './jsonClean.js'
 import { Action } from 'redux'
-import { manifestBaseUrl } from '../../../configuration/variables.js'
+import { manifestBaseUrls } from '../../../configuration/variables.js'
 
 // ------------------------------------
 // Constants
@@ -26,8 +26,8 @@ export function recieveManifest (value: string): Action {
   }
 }
 
-export const fetchManifest = (manifestId): Function => {
-  const baseUrl = manifestBaseUrl
+export const fetchManifest = (base, manifestId): Function => {
+  const baseUrl = manifestBaseUrls[parseInt(base)]
 
   let manifestUrl = baseUrl + manifestId + '.json'
   return (dispatch: Function): Promise => {

--- a/tests/components/OpenSeaDragonPage/modules/buildOpenSeaDragonImage.spec.js
+++ b/tests/components/OpenSeaDragonPage/modules/buildOpenSeaDragonImage.spec.js
@@ -5,6 +5,7 @@ describe('(Module) buildOpenSeaDragonImage', () => {
   const _data = { sequences: { 0: { canvases: { 1: {label: 'label', images: {0:{resource: {'@id': 'http://google.com/image.jpg'}}}}}}}}
 
   const _params = {
+    base: '1',
     manifest: 'manifest',
     sequence: '0',
     view: '1',
@@ -14,7 +15,7 @@ describe('(Module) buildOpenSeaDragonImage', () => {
   const _img = buildOpenSeaDragonImage(_data, _params)
 
   it('Returns a closeUri, imageUri, and label for an OpenSeaDragon image', () => {
-    expect(_img.closeUri).to.equal('/manifest/0/1/1');
+    expect(_img.closeUri).to.equal('/1/manifest/0/1/1');
     expect(_img.imageUri).to.equal('http://google.com/image.jpg');
     expect(_img.label).to.equal('label');
   })

--- a/tests/components/SequenceSelector/modules/targetSequence.spec.js
+++ b/tests/components/SequenceSelector/modules/targetSequence.spec.js
@@ -15,6 +15,7 @@ describe('(Module) targetSequence', () => {
 
   }
   const _params = {
+    base: '1',
     manifest: 'manifest',
     sequence: '2',
     view: '1',
@@ -25,6 +26,6 @@ describe('(Module) targetSequence', () => {
   it('Changes sequence and and sets start page', () => {
 
     let _path = targetSequence(_data, _params, _targetSequence)
-    expect(_path).to.equal('/manifest/0/1/2')
+    expect(_path).to.equal('/1/manifest/0/1/2')
   })
 })

--- a/tests/modules/buildArtifactImage.spec.js
+++ b/tests/modules/buildArtifactImage.spec.js
@@ -31,6 +31,7 @@ describe('(Module) buildArtifactImage', () => {
     }
   }
   const _params = {
+    base: '1',
     manifest: 'manifest',
     sequence: '0',
     view: '1',
@@ -42,7 +43,7 @@ describe('(Module) buildArtifactImage', () => {
     expect(_img.canvasId).to.equal(2)
     expect(_img.alt).to.equal('label 1')
     expect(_img.imageUri).to.equal('/uri-1/img.png')
-    expect(_img.objectLink).to.equal('/manifest/0/1/2/detail')
+    expect(_img.objectLink).to.equal('/1/manifest/0/1/2/detail')
   })
 
   it('Returns the current image when passed 0', () => {
@@ -50,7 +51,7 @@ describe('(Module) buildArtifactImage', () => {
     expect(_img.canvasId).to.equal(2)
     expect(_img.alt).to.equal('label 1')
     expect(_img.imageUri).to.equal('/uri-1/img.png')
-    expect(_img.objectLink).to.equal('/manifest/0/1/2/detail')
+    expect(_img.objectLink).to.equal('/1/manifest/0/1/2/detail')
   })
 
   it('Returns the correct image when passed any other number', () => {
@@ -58,7 +59,7 @@ describe('(Module) buildArtifactImage', () => {
     expect(_img.canvasId).to.equal(4)
     expect(_img.alt).to.equal('label 2')
     expect(_img.imageUri).to.equal('/uri-2/img.png')
-    expect(_img.objectLink).to.equal('/manifest/0/1/4/detail')
+    expect(_img.objectLink).to.equal('/1/manifest/0/1/4/detail')
   })
 
 })

--- a/tests/modules/setPage.spec.js
+++ b/tests/modules/setPage.spec.js
@@ -9,6 +9,7 @@ describe('(Module) setPage', () => {
     }
   }
   const _params = {
+    base: '1',
     manifest: 'manifest',
     sequence: '0',
     view: '1',
@@ -18,18 +19,18 @@ describe('(Module) setPage', () => {
   it('Takes the current params and changes the canvasId to the target and returns the new path', () => {
     let _targetPage = '9'
     let _path = setPage(_params, _data, _targetPage)
-    expect(_path).to.equal('/manifest/0/1/9')
+    expect(_path).to.equal('/1/manifest/0/1/9')
   })
 
   it('Prevents navigating below 0', () => {
     let _targetPage = '-1'
     let _path = setPage(_params, _data, _targetPage)
-    expect(_path).to.equal('/manifest/0/1/0')
+    expect(_path).to.equal('/1/manifest/0/1/0')
   })
 
   it('Prevents navigating past the length of the canvases array', () => {
     let _targetPage = '20'
     let _path = setPage(_params, _data, _targetPage)
-    expect(_path).to.equal('/manifest/0/1/15')
+    expect(_path).to.equal('/1/manifest/0/1/15')
   })
 })

--- a/tests/modules/setSequence.spec.js
+++ b/tests/modules/setSequence.spec.js
@@ -2,6 +2,7 @@ import setSequence from 'modules/setSequence.js'
 
 describe('(Module) setSequence', () => {
   const _params = {
+    base: '1',
     manifest: 'manifest',
     sequence: '0',
     view: '1',
@@ -11,13 +12,13 @@ describe('(Module) setSequence', () => {
   it('Changes sequence and defaults to the first page', () => {
     const _targetSequence = '2'
     let _path = setSequence(_params, _targetSequence)
-    expect(_path).to.equal('/manifest/2/1/0')
+    expect(_path).to.equal('/1/manifest/2/1/0')
   })
 
   it('Changes sequence and goes to a target page', () => {
     const _targetSequence = '3'
     const _targetPage = '4'
     let _path = setSequence(_params, _targetSequence, _targetPage)
-    expect(_path).to.equal('/manifest/3/1/4')
+    expect(_path).to.equal('/1/manifest/3/1/4')
   })
 })

--- a/tests/modules/setView.spec.js
+++ b/tests/modules/setView.spec.js
@@ -4,6 +4,7 @@ describe('(Module) setView', () => {
 
   it('Takes the current params and changes the view to the target and returns the new path', () => {
     const _params = {
+      base: '2',
       manifest: 'manifest',
       sequence: '0',
       view: '1',
@@ -11,6 +12,6 @@ describe('(Module) setView', () => {
     }
     const _targetView = 'g'
     let _path = setView(_params, _targetView)
-    expect(_path).to.equal('/manifest/0/g/42')
+    expect(_path).to.equal('/2/manifest/0/g/42')
   })
 })

--- a/tests/modules/targetPath.spec.js
+++ b/tests/modules/targetPath.spec.js
@@ -2,20 +2,22 @@ import targetPath from 'modules/targetPath.js'
 
 describe('(Module) targetPath', () => {
 
-  it('Needs a manifest and can guess at the rest', () => {
+  it('Needs a base and manifest and can guess at the rest', () => {
 
     const _params = {
+      base: '0',
       manifest: 'manifest'
     }
 
     let _path = targetPath(_params)
 
-    expect(_path).to.equal('/manifest/0/g/0')
+    expect(_path).to.equal('/0/manifest/0/g/0')
   })
 
   it('Takes params and returns a path', () => {
 
     const _params = {
+      base: '0',
       manifest: 'manifest',
       sequence: '0',
       view: '1',
@@ -24,12 +26,13 @@ describe('(Module) targetPath', () => {
 
     let _path = targetPath(_params)
 
-    expect(_path).to.equal('/manifest/0/1/42')
+    expect(_path).to.equal('/0/manifest/0/1/42')
   })
 
   it('Takes params and returns a path with details', () => {
 
     const _params = {
+      base: '10',
       manifest: 'manifest',
       sequence: '0',
       view: '1',
@@ -39,6 +42,6 @@ describe('(Module) targetPath', () => {
 
     let _path = targetPath(_params)
 
-    expect(_path).to.equal('/manifest/0/1/42/detail')
+    expect(_path).to.equal('/10/manifest/0/1/42/detail')
   })
 })


### PR DESCRIPTION
It occurred to me that there are various reasons that the manifest files may not all live in the same location online. Some may originate from Curate or Honeycomb, or they may be manually built and uploaded to an s3 location.

* I've added an additional param to the url for `base` that is a numeric id of an array of allowed storage locations defined in the variables.js file.
* Updated tests and documentation with new params information.