### PR TITLE
DAVE-63

### DIFF
--- a/src/components/Drawer/modules/drawerImages.js
+++ b/src/components/Drawer/modules/drawerImages.js
@@ -1,6 +1,8 @@
 import React from 'react'
 import buildArtifactImage from '../../../modules/buildArtifactImage.js'
 import ArtifactImage from '../../ArtifactImage/'
+import canvasIdIsOdd from '../../../modules/canvasIdIsOdd.js'
+import isContinuous from '../../../modules/isContinuous.js'
 import classes from '../Drawer.scss'
 
 function drawerImage (data, params) {
@@ -16,7 +18,8 @@ function drawerImage (data, params) {
 
     // If on TwoUpView and not highlighted, highlight other displayed image.
     if (!highlight && parseInt(params.view) === 2) {
-      if (parseInt(params.canvasId) % 2 === 0) {
+      let isOdd = canvasIdIsOdd(params.canvasId)
+      if (!isOdd || isContinuous(data, params)) {
         highlight = (i === parseInt(params.canvasId) - 1)
       } else if (parseInt(params.canvasId) % 2 === 1) {
         highlight = (i === parseInt(params.canvasId) + 1)

--- a/src/components/Drawer/modules/drawerImages.js
+++ b/src/components/Drawer/modules/drawerImages.js
@@ -21,7 +21,7 @@ function drawerImage (data, params) {
       let isOdd = canvasIdIsOdd(params.canvasId)
       if (!isOdd || isContinuous(data, params)) {
         highlight = (i === parseInt(params.canvasId) - 1)
-      } else if (parseInt(params.canvasId) % 2 === 1) {
+      } else {
         highlight = (i === parseInt(params.canvasId) + 1)
       }
     }

--- a/src/components/TwoUpView/TwoUpView.jsx
+++ b/src/components/TwoUpView/TwoUpView.jsx
@@ -5,6 +5,8 @@ import buildArtifactImage from '../../modules/buildArtifactImage.js'
 import classes from './TwoUpView.scss'
 import OneUpView from '../OneUpView/'
 import canvasIdIsOdd from '../../modules/canvasIdIsOdd.js'
+import isContinuous from '../../modules/isContinuous.js'
+
 class TwoUpView extends Component {
 
   render () {
@@ -26,7 +28,7 @@ class TwoUpView extends Component {
     var imageObject1
     var imageObject2
 
-    if (!isOdd) {
+    if (!isOdd || isContinuous(this.props.data, this.props.params)) {
       imageObject1 = buildArtifactImage(this.props.data, this.props.params, -1)
       imageObject2 = buildArtifactImage(this.props.data, this.props.params)
     } else {

--- a/src/modules/isContinuous.js
+++ b/src/modules/isContinuous.js
@@ -1,0 +1,8 @@
+function isContinuous (data, params) {
+  const hint = data.sequences[params.sequence].viewingHint
+  if (hint) {
+    return hint === 'continuous'
+  }
+  return false
+}
+export default isContinuous

--- a/src/modules/linkBuilder.js
+++ b/src/modules/linkBuilder.js
@@ -1,16 +1,21 @@
 // Build first, last, next, previous links based on the current page (or
 // whatever data and params are passed)
+import isContinuous from './isContinuous.js'
 function linkBuilder (data, params, increment) {
   if (typeof increment === 'undefined') {
-    increment = parseInt(params.view)
+    if (isContinuous(data, params)) {
+      increment = 1
+    } else {
+      increment = parseInt(params.view)
+    }
   }
 
-  var firstPage = 0
-  var lastPage = data.sequences[params.sequence].canvases.length - 1
+  const firstPage = 0
+  const lastPage = data.sequences[params.sequence].canvases.length - 1
 
   // Go back by the increment amount, but do not overshoot the first page
-  var prevPage = Math.max(parseInt(params.canvasId) - increment, firstPage)
-  var nextPage
+  let prevPage = Math.max(parseInt(params.canvasId) - increment, firstPage)
+  let nextPage
 
   // If on 2up display on even numbered page only advance one page to fix sequence
   if (parseInt(params.canvasId) % 2 === 0 && parseInt(params.view) === 2) {

--- a/src/routes/Home/components/HomeView.js
+++ b/src/routes/Home/components/HomeView.js
@@ -82,6 +82,7 @@ export const HomeView = () => (
           <li><Link to='/0/manifest-1/1/2/0?ref=http://onesearch.library.nd.edu/primo_library/libweb/action/search.do;jsessionid=EA0BCCC11BE18F49EF29576941A3A97E?mode=Basic&vid=NDU&tab=onesearch&'>Example 1</Link></li>
           <li><Link to='/0/manifest-3/1/1/16?ref=http://google.com'>Example 2</Link></li>
           <li><Link to='/0/manifest-single/0/1/0'>Example 3</Link></li>
+          <li><Link to='/0/rbsc/0/1/0?ref=http://rarebooks.library.nd.edu'>RBSC Example</Link></li>
           </ul>
       </div>
       <div className={classes.description}>

--- a/tests/modules/isContinuous.spec.js
+++ b/tests/modules/isContinuous.spec.js
@@ -1,0 +1,43 @@
+import isContinuous from 'modules/isContinuous'
+
+describe('(Module) isContinuous', () => {
+  let _result
+  let _params = {
+    sequence: '0'
+  }
+
+  it('Returns true if the viewingHint property is set to "continuous"', () => {
+    let _data = {
+      sequences: {
+        '0': {
+          viewingHint: 'continuous'
+        }
+      }
+    }
+    _result = isContinuous(_data, _params)
+    expect(_result).to.equal(true)
+  })
+
+  it('Returns false if the viewingHint property is not present', () => {
+    let _data = {
+      sequences: {
+        '0': {
+        }
+      }
+    }
+    _result = isContinuous(_data, _params)
+    expect(_result).to.equal(false)
+  })
+
+  it('Returns false if the viewingHint property is present, but not "continuous"', () => {
+    let _data = {
+      sequences: {
+        '0': {
+          viewingHint: 'party time'
+        }
+      }
+    }
+    _result = isContinuous(_data, _params)
+    expect(_result).to.equal(false)
+  })
+})

--- a/tests/modules/linkBuilder.spec.js
+++ b/tests/modules/linkBuilder.spec.js
@@ -82,12 +82,34 @@ describe('(Module) linkBuilder', () => {
       view: '2',
       canvasId: '3'
     }
-    
+
     let _result = linkBuilder(_data, _params, 3)
     expect(_result.increment).to.equal(3)
     expect(_result.firstPage).to.equal(0)
     expect(_result.lastPage).to.equal(5)
     expect(_result.nextPage).to.equal(5)
     expect(_result.prevPage).to.equal(0)
+  })
+
+  it('Advances 1 at a time when it is continuous', () => {
+    const _data_continuous = {
+      sequences: {
+        '0': {
+          canvases: [0, 1, 2, 3, 4, 5],
+          viewingHint: 'continuous'
+        }
+      }
+    }
+    const _params = {
+      sequence: '0',
+      view: '2',
+      canvasId: '3'
+    }
+    let _result = linkBuilder(_data_continuous, _params)
+    expect(_result.increment).to.equal(1)
+    expect(_result.firstPage).to.equal(0)
+    expect(_result.lastPage).to.equal(5)
+    expect(_result.nextPage).to.equal(4)
+    expect(_result.prevPage).to.equal(2)
   })
 })


### PR DESCRIPTION
- Currently, when viewing in two up, if I advance, 2 pages advance.
  So, for instance, I go from viewing pages 3-4, to pages 5-6.  We need
  to allow for going from 3-4 to 4-5.
  - Using the viewingHint property suggested by Ruth, we can set the 2up
    display to advance 1 at a time.
